### PR TITLE
Allow for pseudo-class position with repeat > 9n, no additional offset

### DIFF
--- a/src/PhpCss/Scanner/Patterns.php
+++ b/src/PhpCss/Scanner/Patterns.php
@@ -40,6 +40,6 @@ namespace PhpCss\Scanner {
     const PSEUDO_ELEMENT = '(::[^\r\n\t .,#:()[\\]\\\'"]+)S';
 
     const ATTRIBUTE_OPERATOR = '([~^$*|]?=)S';
-    const PSEUDO_CLASS_POSITION = '(\s*(([-+]?(\\d+)?n\\s*[-+]\\s*\\d+)|\\dn)\s*)';
+    const PSEUDO_CLASS_POSITION = '(\s*(([-+]?(\\d+)?n\\s*[-+]\\s*\\d+)|\\d+n)\s*)';
   }
 }

--- a/tests/PhpCssTest.php
+++ b/tests/PhpCssTest.php
@@ -108,6 +108,7 @@ class PhpCssTest extends \PHPUnit\Framework\TestCase {
       array('tr:nth-child(even)', 'tr:nth-child(2n+0)'),
       array('tr:nth-child(even)', 'tr:nth-child(even)'),
       array('p:nth-child(4n+1)', 'p:nth-child(4n+1)'),
+      array(':nth-child(10n)', ':nth-child(10n)'),
       array(':nth-child(10n-1)', ':nth-child(10n-1)'),
       array(':nth-child(10n+9)', ':nth-child(10n+9)'),
       array('foo:nth-child(5)', 'foo:nth-child(0n+5)'),


### PR DESCRIPTION
I found with selectors that include a pseudo-class with position, such as :nth-child(10n), the parser generates a token mismatch if the NUMBER is more than one digit. I traced this to Scanner/Patterns.php and the PSEUDO_CLASS_POSITION regex. In the second option of the capture group, the match is \d instead of \d+.

I added a test and modified the code to pass.